### PR TITLE
feat: goals 도메인 가계부 챌린지와 연결 및 기초적인 작업

### DIFF
--- a/src/app/budget/page.tsx
+++ b/src/app/budget/page.tsx
@@ -21,7 +21,10 @@ interface ChallengeFormData {
   title: string;
   description: string;
   reason: string;
+  enableAmountGoal: boolean;
+  enableCountGoal: boolean;
   targetAmount: string; // TODO: 카테고리에 따라 필요하지 않을 수도 있음. 검토바람
+  targetCount: string;
   duration: string;
   targetDate: string;
 }
@@ -202,7 +205,10 @@ const BudgetPage = () => {
 
   // 챌린지 생성 핸들러
   const handleChallengeSubmit = (
-    data: ChallengeFormData & { category: string }
+    data: ChallengeFormData & {
+      category: string;
+      categoryType: 'income' | 'expense';
+    }
   ) => {
     if (!user?.id) return;
 
@@ -210,9 +216,13 @@ const BudgetPage = () => {
       title: data.title,
       description: data.description,
       reason: data.reason,
+      enableAmountGoal: data.enableAmountGoal,
+      enableCountGoal: data.enableCountGoal,
       targetAmount: data.targetAmount,
+      targetCount: data.targetCount,
       targetDate: data.targetDate,
       category: data.category,
+      categoryType: data.categoryType,
       userId: user.id,
     });
 

--- a/src/app/goals/page.tsx
+++ b/src/app/goals/page.tsx
@@ -1,0 +1,328 @@
+'use client';
+
+import AuthGuard from '@/components/auth/AuthGuard';
+import GoalCard from '@/components/goals/GoalCard';
+import { useAuth } from '@/hooks/auth';
+import { useGoals } from '@/hooks/goals/useGoals';
+import {
+  Calendar,
+  Clock,
+  Filter,
+  Plus,
+  Search,
+  Target,
+  TrendingUp,
+  Trophy,
+} from 'lucide-react';
+import Link from 'next/link';
+import { useMemo, useState } from 'react';
+
+const GoalsPage = () => {
+  const { user } = useAuth();
+  const { goals, activeGoals, completedGoals, isLoading } = useGoals({
+    userId: user?.id,
+  });
+
+  // 필터 상태
+  const [activeTab, setActiveTab] = useState<
+    'active' | 'completed' | 'paused' | 'cancelled' | 'all'
+  >('active');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [typeFilter, setTypeFilter] = useState<'all' | 'income' | 'expense'>(
+    'all'
+  );
+
+  // 필터링된 목표들
+  const filteredGoals = useMemo(() => {
+    let filtered = goals;
+
+    if (activeTab !== 'all') {
+      filtered = goals.filter((goal) => goal.status === activeTab);
+    }
+
+    if (searchTerm) {
+      filtered = filtered.filter(
+        (goal) =>
+          goal.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+          goal.description?.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    }
+
+    if (typeFilter !== 'all') {
+      filtered = filtered.filter((goal) => {
+        return typeFilter === 'income'
+          ? goal.type === 'increase_income'
+          : goal.type === 'reduce_expense';
+      });
+    }
+
+    return filtered;
+  }, [goals, activeTab, searchTerm, typeFilter]);
+
+  // 통계 계산
+  const statistics = {
+    total: goals.length,
+    active: activeGoals.length,
+    completed: completedGoals.length,
+    completionRate:
+      goals.length > 0 ? (completedGoals.length / goals.length) * 100 : 0,
+  };
+
+  // 핸들러들
+  const handleTypeFilterChange = (value: string) => {
+    if (value === 'all' || value === 'income' || value === 'expense') {
+      setTypeFilter(value);
+    }
+  };
+
+  if (!user?.id) {
+    return (
+      <AuthGuard>
+        <div className="max-w-7xl mx-auto p-4 text-center py-8">
+          <div className="bg-white rounded-lg p-8 shadow-sm border">
+            <h3 className="text-lg font-medium text-gray-600 mb-2">
+              로그인이 필요합니다
+            </h3>
+            <p className="text-gray-500">
+              목표를 관리하려면 먼저 로그인해주세요.
+            </p>
+          </div>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <AuthGuard>
+        <div className="max-w-7xl mx-auto p-4 space-y-6">
+          <div className="animate-pulse space-y-4">
+            <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+            <div className="grid grid-cols-1 gap-4">
+              {[...Array(6)].map((_, i) => (
+                <div key={i} className="h-48 bg-gray-200 rounded-lg"></div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </AuthGuard>
+    );
+  }
+
+  return (
+    <AuthGuard>
+      <div className="max-w-7xl mx-auto p-4 space-y-6">
+        {/* 헤더 */}
+        <div className="flex flex-col gap-4">
+          <div>
+            <h1 className="text-2xl font-bold text-gray-900">내 목표</h1>
+            <p className="text-gray-600 mt-1">
+              진행 중인 챌린지와 달성한 목표를 확인하세요.
+            </p>
+          </div>
+
+          <div className="flex items-center gap-3">
+            <button className="flex items-center gap-2 px-4 py-2 bg-accent-600 text-white rounded-lg hover:bg-accent-700 transition-colors">
+              <Plus className="w-4 h-4" />
+              목표 추가
+            </button>
+          </div>
+        </div>
+
+        {/* 통계 카드 */}
+        <div className="grid grid-cols-2 gap-4">
+          <div className="bg-white p-4 rounded-lg border shadow-sm">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-blue-100 rounded-lg">
+                <Target className="w-5 h-5 text-blue-600" />
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">전체</p>
+                <p className="text-xl font-bold text-gray-900">
+                  {statistics.total}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white p-4 rounded-lg border shadow-sm">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-orange-100 rounded-lg">
+                <Clock className="w-5 h-5 text-orange-600" />
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">진행 중</p>
+                <p className="text-xl font-bold text-gray-900">
+                  {statistics.active}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white p-4 rounded-lg border shadow-sm">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-green-100 rounded-lg">
+                <Trophy className="w-5 h-5 text-green-600" />
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">완료</p>
+                <p className="text-xl font-bold text-gray-900">
+                  {statistics.completed}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="bg-white p-4 rounded-lg border shadow-sm">
+            <div className="flex items-center gap-3">
+              <div className="p-2 bg-purple-100 rounded-lg">
+                <Calendar className="w-5 h-5 text-purple-600" />
+              </div>
+              <div>
+                <p className="text-sm text-gray-600">달성률</p>
+                <p className="text-xl font-bold text-gray-900">
+                  {Math.round(statistics.completionRate)}%
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* 필터 및 검색 */}
+        <div className="bg-white p-4 rounded-lg border shadow-sm">
+          <div className="flex flex-col md:flex-row gap-4">
+            {/* 탭 */}
+            <div className="flex bg-gray-100 rounded-lg p-1">
+              <button
+                onClick={() => setActiveTab('active')}
+                className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+                  activeTab === 'active'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                진행 ({statistics.active})
+              </button>
+              <button
+                onClick={() => setActiveTab('completed')}
+                className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+                  activeTab === 'completed'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                완료 ({statistics.completed})
+              </button>
+              <button
+                onClick={() => setActiveTab('paused')}
+                className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+                  activeTab === 'completed'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                멈춤 ({statistics.completed})
+              </button>
+              <button
+                onClick={() => setActiveTab('cancelled')}
+                className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+                  activeTab === 'completed'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                취소 ({statistics.completed})
+              </button>
+              <button
+                onClick={() => setActiveTab('all')}
+                className={`flex-1 px-4 py-2 text-sm font-medium rounded-md transition-colors ${
+                  activeTab === 'all'
+                    ? 'bg-white text-gray-900 shadow-sm'
+                    : 'text-gray-600 hover:text-gray-900'
+                }`}
+              >
+                전체 ({statistics.total})
+              </button>
+            </div>
+
+            {/* 검색 */}
+            <div className="flex-1 relative">
+              <Search className="w-4 h-4 absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400" />
+              <input
+                type="text"
+                placeholder="목표 제목이나 설명으로 검색..."
+                value={searchTerm}
+                onChange={(e) => setSearchTerm(e.target.value)}
+                className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
+              />
+            </div>
+
+            {/* 타입 필터 */}
+            <div className="flex items-center gap-2">
+              <Filter className="w-4 h-4 text-gray-400" />
+              <select
+                value={typeFilter}
+                onChange={(e) => handleTypeFilterChange(e.target.value)}
+                className="px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
+              >
+                <option value="all">전체</option>
+                <option value="income">수입 증가</option>
+                <option value="expense">지출 감소</option>
+              </select>
+            </div>
+          </div>
+        </div>
+
+        {/* 목표 목록 */}
+        {filteredGoals.length > 0 ? (
+          <div className="grid grid-cols-1 gap-6">
+            {filteredGoals.map((goal) => (
+              <GoalCard key={goal.id} goal={goal} />
+            ))}
+          </div>
+        ) : (
+          <div className="bg-white rounded-lg p-12 shadow-sm border text-center">
+            <div className="text-gray-400 mb-4">
+              <Target className="w-16 h-16 mx-auto" />
+            </div>
+            <h3 className="text-xl font-medium text-gray-600 mb-2">
+              {activeTab === 'active'
+                ? '진행 중인 목표가 없습니다.'
+                : activeTab === 'completed'
+                  ? '완료된 목표가 없습니다.'
+                  : searchTerm
+                    ? '검색 결과가 없습니다.'
+                    : '아직 목표가 없습니다.'}
+            </h3>
+            <p className="text-gray-500 mb-6">
+              {activeTab === 'active'
+                ? '가계부에서 챌린지를 시작하거나 새로운 목표를 만들어보세요.'
+                : activeTab === 'completed'
+                  ? '목표를 달성하면 여기에 표시됩니다.'
+                  : searchTerm
+                    ? '다른 검색어로 시도해보세요.'
+                    : '첫 번째 목표를 만들어 성장을 시작해보세요.'}
+            </p>
+            {!searchTerm && (
+              <div className="flex flex-col justify-center">
+                <button className="inline-flex items-center gap-2 px-6 py-3 bg-accent-600 text-white rounded-lg hover:bg-accent-700 transition-colors">
+                  <Plus className="w-4 h-4" />
+                  목표 추가
+                </button>
+                <Link
+                  href="/budget"
+                  className="inline-flex items-center gap-2 px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+                >
+                  <TrendingUp className="w-4 h-4" />
+                  가계부 챌린지
+                </Link>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </AuthGuard>
+  );
+};
+
+export default GoalsPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter } from 'next/font/google';
 import './globals.css';
 import Providers from './providers';
 import Header from '@/components/layout/Header';
+import TransactionAlertProvider from '@/components/budget/TransactionAlertProvider';
 const inter = Inter({ subsets: ['latin'] });
 
 export const metadata = {
@@ -24,11 +25,13 @@ export default function RootLayout({
       </head>
       <body className={`${inter.className} bg-gray-50 min-h-screen`}>
         <Providers>
-          <div className="min-h-screen flex flex-col">
-            <Header />
-            <main className="flex-1">{children}</main>
-            {/* // TODO: Footer 추가 */}
-          </div>
+          <TransactionAlertProvider>
+            <div className="min-h-screen flex flex-col">
+              <Header />
+              <main className="flex-1">{children}</main>
+              {/* // TODO: Footer 추가 */}
+            </div>
+          </TransactionAlertProvider>
         </Providers>
       </body>
     </html>

--- a/src/components/budget/ChallengeModal.tsx
+++ b/src/components/budget/ChallengeModal.tsx
@@ -21,7 +21,12 @@ interface ChallengeFormData {
 interface ChallengeModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSubmit: (data: ChallengeFormData & { category: string }) => void;
+  onSubmit: (
+    data: ChallengeFormData & {
+      category: string;
+      categoryType: 'income' | 'expense';
+    }
+  ) => void;
   challengeData: {
     name: string;
     amount: number;
@@ -116,7 +121,8 @@ const ChallengeModal = ({
     e.preventDefault();
     onSubmit({
       ...formData,
-      category: '가계부',
+      category: challengeData.category,
+      categoryType: challengeData.type,
     });
   };
 

--- a/src/components/budget/TransactionAlertProvider.tsx
+++ b/src/components/budget/TransactionAlertProvider.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { createContext, ReactNode, useContext } from 'react';
+import GoalUpdateNotification from '../goals/GoalUpdateNotification';
+import { useTransactionAlert } from '@/hooks/budget/useTransactionAlert';
+
+interface TransactionAlertContextType {
+  showAlert: (categoryName: string, type: 'income' | 'expense') => void;
+  hideAlert: (categoryName: string) => void;
+  clearAllAlerts: () => void;
+}
+
+const TransactionAlertContext =
+  createContext<TransactionAlertContextType | null>(null);
+
+export const useTransactionAlertContext = () => {
+  const context = useContext(TransactionAlertContext);
+  if (!context) {
+    throw new Error(
+      'useTransactionAlertContext must be used within a TransactionAlertProvider'
+    );
+  }
+  return context;
+};
+
+interface TransactionAlertProviderProps {
+  children: ReactNode;
+}
+
+const TransactionAlertProvider = ({
+  children,
+}: TransactionAlertProviderProps) => {
+  const { alerts, showAlert, hideAlert, clearAllAlerts } =
+    useTransactionAlert();
+
+  return (
+    <TransactionAlertContext.Provider
+      value={{ showAlert, hideAlert, clearAllAlerts }}
+    >
+      {children}
+
+      {/* 알림들 렌더링 */}
+      {alerts.map((alert) => (
+        <GoalUpdateNotification
+          key={`${alert.categoryName}-${alert.type}`}
+          categoryName={alert.categoryName}
+          onClose={() => hideAlert(alert.categoryName)}
+        />
+      ))}
+    </TransactionAlertContext.Provider>
+  );
+};
+
+export default TransactionAlertProvider;

--- a/src/components/goals/GoalCard.tsx
+++ b/src/components/goals/GoalCard.tsx
@@ -1,0 +1,106 @@
+import { Goal, GoalProgressInfo } from '@/types/goals';
+import { format } from 'date-fns';
+import { ko } from 'date-fns/locale';
+import { CheckCircle, TrendingDown, TrendingUp } from 'lucide-react';
+
+interface GoalCardProps {
+  goal: Goal & { progress: GoalProgressInfo };
+}
+
+const GoalCard = ({ goal }: GoalCardProps) => {
+  const { progress } = goal;
+
+  return (
+    <div
+      className={`bg-white rounded-lg p-6 shadow-sm border transition-all hover:shadow-md ${
+        progress.isComplete
+          ? 'border-green-200 bg-green-50/30'
+          : 'border-gray-200'
+      }`}
+    >
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-center gap-3">
+          <div
+            className={`p-2 rounded-lg ${
+              goal.type === 'increase_income'
+                ? 'bg-green-100 text-green-600'
+                : 'bg-red-100 text-red-600'
+            }`}
+          >
+            {goal.type === 'increase_income' ? (
+              <TrendingUp className="w-5 h-5" />
+            ) : (
+              <TrendingDown className="w-5 h-5" />
+            )}
+          </div>
+          <div>
+            <h3 className="font-semibold text-gray-900">{goal.title}</h3>
+            <p className="text-sm text-gray-600">{progress.progressText}</p>
+          </div>
+        </div>
+
+        {progress.isComplete && (
+          <CheckCircle className="w-6 h-6 text-green-600" />
+        )}
+      </div>
+
+      {/* 진행률 바 */}
+      <div className="mb-4">
+        <div className="flex justify-between text-sm text-gray-600 mb-2">
+          <span>진행률</span>
+          <span>{Math.round(progress.overallProgress)}%</span>
+        </div>
+        <div className="w-full bg-gray-200 rounded-full h-2">
+          <div
+            className={`h-2 rounded-full transition-all duration-300 ${
+              progress.isComplete ? 'bg-green-500' : 'bg-accent-500'
+            }`}
+            style={{ width: `${Math.min(100, progress.overallProgress)}%` }}
+          />
+        </div>
+      </div>
+
+      {/* 목표 상세 정보 */}
+      <div className="space-y-2 text-sm">
+        {goal.target_amount && (
+          <div className="flex justify-between">
+            <span className="text-gray-600">금액 목표:</span>
+            <span className="font-medium">
+              {goal.current_amount.toLocaleString()} /{' '}
+              {goal.target_amount.toLocaleString()}원
+            </span>
+          </div>
+        )}
+
+        {goal.target_count && (
+          <div className="flex justify-between">
+            <span className="text-gray-600">횟수 목표:</span>
+            <span className="font-medium">
+              {goal.current_count} / {goal.target_count}회
+            </span>
+          </div>
+        )}
+
+        {goal.target_date && (
+          <div className="flex justify-between">
+            <span className="text-gray-600">마감일:</span>
+            <span className="font-medium">
+              {format(new Date(goal.target_date), 'yyyy년 M월 d일', {
+                locale: ko,
+              })}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* 이유 */}
+      {goal.reason && (
+        <div className="mt-4 p-3 bg-gray-50 rounded-lg">
+          <p className="text-sm text-gray-700">{goal.reason}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GoalCard;

--- a/src/components/goals/GoalCompletionNotification.tsx
+++ b/src/components/goals/GoalCompletionNotification.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { CheckCircle, Trophy, X } from 'lucide-react';
+import { useEffect, useState } from 'react';
+
+interface GoalCompletionNotificationProps {
+  goalTitle: string;
+  onClose: () => void;
+  autoCloseDelay?: number;
+}
+
+const GoalCompletionNotification = ({
+  goalTitle,
+  onClose,
+  autoCloseDelay = 5000,
+}: GoalCompletionNotificationProps) => {
+  const [isVisible, setIsVisible] = useState(true);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsVisible(false);
+      setTimeout(onClose, 300);
+    }, autoCloseDelay);
+
+    return () => clearTimeout(timer);
+  }, [autoCloseDelay, onClose]);
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="fixed top-4 right-4 bg-gradient-to-r from-green-500 to-green-600 text-white rounded-lg shadow-2xl p-6 max-w-sm z-50 animate-in slide-in-from-right duration-300">
+      <div className="flex items-start gap-4">
+        <div className="p-2 bg-white/20 rounded-full">
+          <Trophy className="w-6 h-6" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <CheckCircle className="w-5 h-5" />
+            <h3 className="font-bold text-lg">목표 달성!</h3>
+          </div>
+          <p className="text-green-100 text-sm mb-2">
+            {goalTitle} 챌린지를 성공적으로 완료했습니다!
+          </p>
+          <p className="text-green-200 text-xs">
+            축하합니다! 꾸준한 노력이 결실을 맺었네요.
+          </p>
+        </div>
+
+        <button
+          onClick={() => {
+            setIsVisible(false);
+            setTimeout(onClose, 300);
+          }}
+          className="p-1 text-white/80 hover:text-white transition-colors"
+        >
+          <X className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default GoalCompletionNotification;

--- a/src/components/goals/GoalCompletionProvider.tsx
+++ b/src/components/goals/GoalCompletionProvider.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useGoalCompletionAlert } from '@/hooks/goals/useFoalCompletionAlert';
+import { ReactNode } from 'react';
+import GoalCompletionNotification from './GoalCompletionNotification';
+
+interface GoalCompletionProviderProps {
+  children: ReactNode;
+}
+
+const GoalCompletionProvider = ({ children }: GoalCompletionProviderProps) => {
+  const { completedGoals, hideCompletionAlert } = useGoalCompletionAlert();
+
+  return (
+    <>
+      {children}
+
+      {/* 완료 알림들 렌더링 */}
+      {completedGoals.map((goal) => (
+        <GoalCompletionNotification
+          key={goal.id}
+          goalTitle={goal.title}
+          onClose={() => hideCompletionAlert(goal.id)}
+        />
+      ))}
+    </>
+  );
+};
+
+export default GoalCompletionProvider;

--- a/src/components/goals/GoalEditModal.tsx
+++ b/src/components/goals/GoalEditModal.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useGoals } from '@/hooks/goals/useGoals';
+import { Goal } from '@/types/goals';
+import { useState } from 'react';
+import Modal from '../common/Modal';
+import { Target, TrendingDown, TrendingUp } from 'lucide-react';
+import { format } from 'date-fns';
+
+interface GoalEditModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  goals: Array<{ goal: Goal; currentAmount: number; currentCount: number }>;
+  currentIndex: number;
+  totalCount: number;
+}
+
+const GoalEditModal = ({
+  isOpen,
+  onClose,
+  goals,
+  currentIndex,
+  totalCount,
+}: GoalEditModalProps) => {
+  const { updateGoal, isUpdatingGoal } = useGoals();
+
+  const currentGoalData = goals[currentIndex];
+  const { goal, currentAmount, currentCount } = currentGoalData;
+
+  const [formData, setFormData] = useState({
+    target_amount: goal.target_amount?.toString() || '',
+    target_count: goal.target_count?.toString() || '',
+    target_date: goal.target_date?.toString() || '',
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+
+    updateGoal({
+      id: goal.id,
+      target_amount: formData.target_amount
+        ? Number(formData.target_amount)
+        : null,
+      target_count: formData.target_count
+        ? Number(formData.target_count)
+        : null,
+      target_date: formData.target_date || null,
+    });
+
+    // 다음 목표로 이동 또는 완료
+    if (currentIndex + 1 < totalCount) {
+      // 다음 목표의 데이터로 폼 초기화
+      const nextGoal = goals[currentIndex + 1].goal;
+      setFormData({
+        target_amount: nextGoal.target_amount?.toString() || '',
+        target_count: nextGoal.target_count?.toString() || '',
+        target_date: nextGoal.target_date?.toString() || '',
+      });
+    }
+
+    onClose(); // 부모 컴포넌트에서 다음 목표 처리
+  };
+
+  const isIncome = goal.type === 'increase_income';
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="md">
+      <Modal.Header>
+        <div className="flex items-center gap-3">
+          <div className="p-2 bg-amber-100 rounded-lg">
+            <Target className="w-5 h-5 text-amber-600" />
+          </div>
+          <div>
+            <Modal.Title>
+              챌린지 수정 ({currentIndex + 1}/{totalCount})
+            </Modal.Title>
+            <Modal.Description>
+              거래 내역 변경으로 인해 목표를 조정하세요.
+            </Modal.Description>
+          </div>
+        </div>
+      </Modal.Header>
+
+      <Modal.Body>
+        <div className="space-y-6">
+          {/* 현재 상황 표시 */}
+          <div className="bg-gray-50 rounded-lg p-4">
+            <h3 className="font-medium text-gray-900 mb-3 flex items-center gap-2">
+              {isIncome ? (
+                <TrendingUp className="w-4 h-4 text-green-600" />
+              ) : (
+                <TrendingDown className="w-4 h-4 text-red-600" />
+              )}
+              {goal.title}
+            </h3>
+
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <span className="text-gray-600">현재 실제:</span>
+                <div className="font-medium">
+                  {currentAmount.toLocaleString()}원 ({currentCount}건)
+                </div>
+              </div>
+              <div>
+                <span className="text-gray-600">기존 목표:</span>
+                <div className="font-medium">
+                  {goal.target_amount?.toLocaleString() || 0}원 (
+                  {goal.target_count || 0}건)
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {/* 목표 금액 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                목표 금액
+              </label>
+              <div className="relative">
+                <input
+                  type="number"
+                  value={formData.target_amount}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      target_amount: e.target.value,
+                    }))
+                  }
+                  placeholder={currentAmount.toString()}
+                  className="w-full px-3 py-2 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
+                />
+                <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 text-sm">
+                  원
+                </span>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                현재 실제 금액: {currentAmount.toLocaleString()}원
+              </p>
+            </div>
+
+            {/* 목표 횟수 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                목표 횟수
+              </label>
+              <div className="relative">
+                <input
+                  type="number"
+                  value={formData.target_count}
+                  onChange={(e) =>
+                    setFormData((prev) => ({
+                      ...prev,
+                      target_count: e.target.value,
+                    }))
+                  }
+                  placeholder={currentCount.toString()}
+                  className="w-full px-3 py-2 pr-12 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
+                />
+                <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-500 text-sm">
+                  회
+                </span>
+              </div>
+              <p className="text-xs text-gray-500 mt-1">
+                현재 실제 횟수: {currentCount}회
+              </p>
+            </div>
+
+            {/* 마감일 */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-2">
+                마감일
+              </label>
+              <input
+                type="date"
+                value={formData.target_date}
+                onChange={(e) =>
+                  setFormData((prev) => ({
+                    ...prev,
+                    target_date: e.target.value,
+                  }))
+                }
+                min={format(new Date(), 'yyyy-MM-dd')}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-accent-500 focus:border-accent-500"
+              />
+            </div>
+          </form>
+        </div>
+      </Modal.Body>
+
+      <Modal.Footer>
+        <Modal.CloseButton>취소</Modal.CloseButton>
+        <Modal.Button
+          type="submit"
+          form="goal-edit-form"
+          loading={isUpdatingGoal}
+          onClick={handleSubmit}
+        >
+          수정하기
+        </Modal.Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default GoalEditModal;

--- a/src/components/goals/GoalUpdateNotification.tsx
+++ b/src/components/goals/GoalUpdateNotification.tsx
@@ -1,0 +1,96 @@
+'use client';
+
+import { useAuth } from '@/hooks/auth';
+import { useGoalChecker } from '@/hooks/goals/useGoalChecker';
+import { AlertTriangle, Edit3, X } from 'lucide-react';
+import { useState } from 'react';
+import GoalEditModal from './GoalEditModal';
+
+interface GoalUpdateNotificationProps {
+  categoryName: string;
+  onClose: () => void;
+}
+
+const GoalUpdateNotification = ({
+  categoryName,
+  onClose,
+}: GoalUpdateNotificationProps) => {
+  const { user } = useAuth();
+  const { affectedGoals, hasAffectedGoals } = useGoalChecker(
+    user?.id,
+    categoryName
+  );
+  const [currentEditIndex, setCurrentEditIndex] = useState(-1);
+
+  // 편집할 목표들 준비
+  const editableGoals = affectedGoals.map((goalData) => ({
+    goal: goalData,
+    currentAmount: goalData.currentMonthAmount,
+    currentCount: goalData.currentMonthCount,
+  }));
+
+  if (!hasAffectedGoals) return null;
+
+  return (
+    <>
+      <div className="fixed bottom-4 right-4 bg-white border border-amber-200 rounded-lg shadow-lg p-4 max-w-sm z-50">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="w-5 h-5 text-amber-500 flex-shrink-0 mt-0.5" />
+          <div className="flex-1 min-w-0">
+            <p className="text-sm font-medium text-gray-900">
+              {categoryName} 챌린지 업데이트 필요
+            </p>
+            <p className="text-xs text-gray-600 mt-1">
+              내역이 변경되어 {affectedGoals.length}개의 챌린지를 수정해야
+              합니다.
+            </p>
+
+            {affectedGoals.length === 1 ? (
+              <button
+                onClick={() => setCurrentEditIndex(0)}
+                className="flex items-center gap-1 px-2 py-1 text-xs bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors"
+              >
+                <Edit3 className="w-3 h-3" />
+                챌린지 수정
+              </button>
+            ) : (
+              <button
+                onClick={() => setCurrentEditIndex(0)}
+                className="flex items-center gap-1 px-2 py-1 text-xs bg-amber-600 text-white rounded hover:bg-amber-700 transition-colors"
+              >
+                <Edit3 className="w-3 h-3" />
+                챌린지 수정 (1/{affectedGoals.length})
+              </button>
+            )}
+          </div>
+
+          <button
+            onClick={onClose}
+            className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+
+      {currentEditIndex >= 0 && (
+        <GoalEditModal
+          isOpen={true}
+          onClose={() => {
+            if (currentEditIndex + 1 < editableGoals.length) {
+              setCurrentEditIndex((prev) => prev + 1);
+            } else {
+              setCurrentEditIndex(-1);
+              onClose();
+            }
+          }}
+          goals={editableGoals}
+          currentIndex={currentEditIndex}
+          totalCount={editableGoals.length}
+        />
+      )}
+    </>
+  );
+};
+
+export default GoalUpdateNotification;

--- a/src/hooks/budget/useTransactionAlert.ts
+++ b/src/hooks/budget/useTransactionAlert.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from 'react';
+
+interface TransactionAlert {
+  categoryName: string;
+  type: 'income' | 'expense';
+  isVisible: boolean;
+}
+
+export const useTransactionAlert = () => {
+  const [alerts, setAlerts] = useState<TransactionAlert[]>([]);
+
+  const showAlert = useCallback((categoryName: string, type: 'income' | 'expense') => {
+    // 중복 알림 방지
+    setAlerts(prev => {
+      const exists = prev.some(alert =>
+        alert.categoryName === categoryName && alert.type === type
+      );
+
+      if (exists) return prev;
+
+      return [...prev, { categoryName, type, isVisible: true }];
+    });
+  }, []);
+
+  const hideAlert = useCallback((categoryName: string) => {
+    setAlerts(prev => prev.filter(alert => alert.categoryName !== categoryName));
+  }, []);
+
+  const clearAllAlerts = useCallback(() => {
+    setAlerts([]);
+  }, []);
+
+  return {
+    alerts,
+    showAlert,
+    hideAlert,
+    clearAllAlerts,
+  };
+};

--- a/src/hooks/goals/useFoalCompletionAlert.ts
+++ b/src/hooks/goals/useFoalCompletionAlert.ts
@@ -1,0 +1,30 @@
+import { useCallback, useState } from 'react';
+
+interface CompletedGoal {
+  id: string;
+  title: string;
+}
+
+export const useGoalCompletionAlert = () => {
+  const [completedGoals, setCompletedGoals] = useState<CompletedGoal[]>([]);
+  
+  const showCompletionAlert = useCallback((goal: CompletedGoal) => {
+    setCompletedGoals(prev => {
+      // 중복 방지
+      const exists = prev.some(g => g.id === goal.id);
+      if (exists) return prev;
+
+      return [...prev, goal];
+    });
+  }, []);
+
+  const hideCompletionAlert = useCallback((goalId: string) => {
+    setCompletedGoals(prev => prev.filter(g => g.id !== goalId));
+  }, []);
+
+  return {
+    completedGoals,
+    showCompletionAlert,
+    hideCompletionAlert,
+  };
+};

--- a/src/hooks/goals/useGoalChecker.ts
+++ b/src/hooks/goals/useGoalChecker.ts
@@ -1,0 +1,77 @@
+import { supabase } from '@/lib/supabase';
+import { Goal } from '@/types/goals';
+import { useQuery } from '@tanstack/react-query';
+import { endOfMonth, format, startOfMonth } from 'date-fns';
+
+interface GoalWithCurrentData extends Goal {
+  currentMonthAmount: number;
+  currentMonthCount: number;
+  hasDataMismatch: boolean;
+}
+
+export const useGoalChecker = (userId?: string, categoryName?: string) => {
+  const { data: affectedGoals = [] } = useQuery({
+    queryKey: ['affected-goals', userId, categoryName],
+    queryFn: async (): Promise<GoalWithCurrentData[]> => {
+      if (!userId || !categoryName) return [];
+
+      // 현재 월의 시작일과 종료일
+      const now = new Date();
+      const monthStart = format(startOfMonth(now), 'yyyy-MM-dd');
+      const monthEnd = format(endOfMonth(now), 'yyyy-MM-dd');
+      // 활성화된 목표들 조회
+      const { data: goals, error: goalsError } = await supabase
+        .from('goals')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('status', 'active')
+
+      if (goalsError) throw goalsError;
+      if (!goals || goals.length === 0) return [];
+
+      // 각 목표에 대해 현재 월 실제 데이터 계산
+      const goalsWithCurrentData = await Promise.all(
+        goals.map(async (goal) => {
+          const tableName = goal.type === 'increase_income' ? 'incomes' : 'expenses';
+
+          // 해당 목표와 연관될 수 있는 카테고리의 현재 월 데이터 조회
+          const { data: transactions } = await supabase
+            .from(tableName)
+            .select('amount, category:categories(name)')
+            .eq('user_id', userId)
+            .gte('date', monthStart)
+            .lte('date', monthEnd);
+
+          // 해당 카테고리 이름과 관련된 데이터 집계
+          const relatedTransactions = (transactions || []).filter(t => 
+            t.category && 'name' in t.category && t.category.name === categoryName
+          );
+
+          const currentMonthAmount = relatedTransactions.reduce((sum, t) => sum + t.amount, 0);
+          const currentMonthCount = relatedTransactions.length;
+
+          // 데이터 불일치 여부 확인
+          const hasDataMismatch =
+            goal.current_amount !== currentMonthAmount || // 1원 이상 차이
+            goal.current_count !== currentMonthCount; // 1회 이상 차이
+
+          return {
+            ...goal,
+            currentMonthAmount,
+            currentMonthCount,
+            hasDataMismatch
+          };
+        })
+      );
+
+      // 불일치가 있는 목표들만 반환
+      return goalsWithCurrentData.filter(goal => goal.hasDataMismatch);
+    },
+    enabled: !!userId && !!categoryName,
+  });
+
+  return {
+    affectedGoals,
+    hasAffectedGoals: affectedGoals.length > 0,
+  };
+};

--- a/src/hooks/goals/useGoalStatusUpdater.ts
+++ b/src/hooks/goals/useGoalStatusUpdater.ts
@@ -1,0 +1,136 @@
+import { supabase } from '@/lib/supabase';
+import { useQueryClient } from '@tanstack/react-query'
+import { useGoalCompletionAlert } from './useFoalCompletionAlert';
+
+export const useGoalStatusUpdater = () => {
+  const queryClient = useQueryClient();
+  const { showCompletionAlert } = useGoalCompletionAlert();
+
+  const checkAndUpdateGoalStatus = async (goalId: string, userId: string) => {
+    try {
+      // 목표 정보 조회
+      const { data: goal, error: goalError } = await supabase
+        .from('goals')
+        .select('*')
+        .eq('id', goalId)
+        .eq('user_id', userId)
+        .single();
+
+      if (goalError || !goal) {
+        console.error('목표 조회 실패:', goalError);
+        return;
+      }
+
+      // 이미 완료된 목표는 건너뛰기
+      if (goal.status === 'completed') return;
+
+      // 현재 월의 실제 데이터 조회
+      const now = new Date();
+      const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0];
+      const monthEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0).toISOString().split('T')[0];
+
+      const tableName = goal.type === 'increase_income' ? 'incomes' : 'expenses';
+
+      const { data: transactions } = await supabase
+        .from(tableName)
+        .select('amount')
+        .eq('user_id', userId)
+        .gte('date', monthStart)
+        .lte('date', monthEnd);
+
+      if (!transactions) return;
+
+      // 실제 달성 현황 계산
+      const actualAmount = transactions.reduce((sum, t) => sum + t.amount, 0);
+      const actualCount = transactions.length;
+
+      // 목표 달성 여부 확인
+      let isCompleted = false;
+
+      if (goal.challenge_mode === 'amount') {
+        isCompleted = goal.target_amount ? actualAmount >= goal.target_amount : false;
+      } else if (goal.challenge_mode === 'count') {
+        isCompleted = goal.target_count ? actualCount >= goal.target_count : false;
+      } else { // 'both' - OR 조건
+        const amountComplete = goal.target_amount ? actualAmount >= goal.target_amount : true;
+        const countComplete = goal.target_count ? actualCount >= goal.target_count : true;
+        isCompleted = amountComplete || countComplete;
+      }
+
+      // 목표 달성 시 상태 업데이트
+      if (isCompleted) {
+        const { error: updateError } = await supabase
+          .from('goals')
+          .update({
+            status: 'completed',
+            current_amount: actualAmount,
+            current_count: actualCount,
+          })
+          .eq('id', goalId);
+
+        if (updateError) {
+          console.error('목표 상태 업데이트 실패:', updateError);
+        } else {
+          // 캐시 무효화
+          queryClient.invalidateQueries({ queryKey: ['goals'] });
+
+          // 완료 알림 표시
+          showCompletionAlert({
+            id: goal.id,
+            title: goal.totle,
+          });
+        }
+      } else {
+        // 완료되지 않았지만 current 값은 업데이트
+        const { error: updateError } = await supabase
+          .from('goals')
+          .update({
+            current_amount: actualAmount,
+            current_count: actualCount,
+          })
+          .eq('id', goalId);
+
+        if (updateError) {
+          console.error('목표 진행률 업데이트 실패:', updateError);
+        }
+      }
+
+    } catch (error) {
+      console.error('목표 상태 확인 중 오류:', error);
+    }
+  };
+
+  // 여러 목표를 배치로 확인
+  const checkMultipleGoals = async (goalIds: string[], userId: string) => {
+    await Promise.allSettled(
+      goalIds.map(goalId => checkAndUpdateGoalStatus(goalId, userId))
+    );
+  };
+
+  // 특정 카테고리와 관련된 모든 목표 확인
+  const checkGoalsByCategory = async (userId: string, categoryName: string, type: 'income' | 'expense') => {
+    try {
+      const goalType = type === 'income' ? 'increase_income' : 'reduce_expense';
+
+      const { data: goals } = await supabase
+        .from('goals')
+        .select('id')
+        .eq('user_id', userId)
+        .eq('type', goalType)
+        .eq('status', 'active')
+
+      if (goals && goals.length > 0) {
+        const goalIds = goals.map(g => g.id);
+        await checkMultipleGoals(goalIds, userId);
+      }
+    } catch (error) {
+      console.error('카테고리별 목표 확인 실패:', error);
+    }
+  };
+
+  return {
+    checkAndUpdateGoalStatus,
+    checkMultipleGoals,
+    checkGoalsByCategory,
+  };
+};

--- a/src/hooks/goals/useGoals.ts
+++ b/src/hooks/goals/useGoals.ts
@@ -1,0 +1,191 @@
+import { supabase } from '@/lib/supabase';
+import { Goal, GoalFormData, GoalProgressInfo } from '@/types/goals';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMemo } from 'react';
+
+interface UseGoalsProps {
+  userId?: string;
+  status?: Goal['status'];
+}
+
+export const useGoals = ({ userId, status }: UseGoalsProps = {}) => {
+  const queryClient = useQueryClient();
+
+  // 목표 조회
+  const { data: goals = [], isLoading, error } = useQuery({
+    queryKey: ['goals', userId, status],
+    queryFn: async (): Promise<Goal[]> => {
+      let query = supabase
+        .from('goals')
+        .select(`
+          *,
+          category:categories(*)
+        `)
+        .order('created_at', { ascending: false });
+      
+      if (userId) {
+        query = query.eq('user_id', userId);
+      }
+
+      if (status) {
+        query = query.eq('status', status);
+      }
+
+      const { data, error } = await query;
+      if (error) throw error;
+      return data || [];
+    },
+    enabled: !!userId,
+  });
+
+  // 목표 생성
+  const createGoalMutation = useMutation({
+    mutationFn: async (newGoal: GoalFormData & { user_id: string }) => {
+      const goalData = {
+        ...newGoal,
+        current_amount: 0,
+        current_count: 0,
+        status: 'active' as const,
+        created_from_date: new Date().toISOString().split('T')[0],
+      };
+
+      const { data, error } = await supabase
+        .from('goals')
+        .insert([goalData])
+        .select(`
+          *,
+          category:categories(*)
+        `)
+        .single();
+
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['goals'] });
+    }
+  });
+
+  // 목표 수정
+  const updateGoalMutation = useMutation({
+    mutationFn: async (updates: { id: string } & Partial<Goal>) => {
+      const { id, ...goalUpdates } = updates;
+
+      const { data, error } = await supabase
+        .from('goals')
+        .update(goalUpdates)
+        .eq('id', id)
+        .select(`
+          *,
+          category:categories(*)
+        `)
+        .single();
+
+      if (error) throw error;
+      return data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['goals'] });
+    },
+  });
+
+  // 목표 진행률 계산
+  const goalsWithProgress = useMemo(() => {
+    return goals.map(goal => {
+      const progressInfo = calculateGoalProgress(goal);
+      return {
+        ...goal,
+        progress: progressInfo,
+      };
+    });
+  }, [goals]);
+
+  // 활성 목표만 필터링
+  const activeGoals = useMemo(() => {
+    return goalsWithProgress.filter(goal => goal.status === 'active');
+  }, [goalsWithProgress]);
+
+  // 완료된 목표만 필터링
+  const completedGoals = useMemo(() => {
+    return goalsWithProgress.filter(goal => goal.status === 'completed');
+  }, [goalsWithProgress]);
+
+  return {
+  goals: goalsWithProgress,
+  activeGoals,
+  completedGoals,
+  isLoading,
+  error,
+  createGoal: createGoalMutation.mutate,
+  isCreatingGoal: createGoalMutation.isPending,
+  updateGoal: updateGoalMutation.mutate,
+  isUpdatingGoal: updateGoalMutation.isPending,
+  };
+} ;
+
+// 목표 진행률 계산 함수
+const calculateGoalProgress = (goal: Goal): GoalProgressInfo => {
+  const currentDate = new Date();
+  const targetDate = goal.target_date ? new Date(goal.target_date) : null;
+
+  // 남은 일수 계산
+  const daysLeft = targetDate
+    ? Math.max(0, Math.ceil((targetDate.getTime() - currentDate.getTime()) / (1000 * 60 * 60 * 24)))
+    : 0;
+
+  // 금액 진행률 계산
+  const amountProgress = goal.target_amount && goal.target_amount > 0
+    ? Math.min(100, (goal.current_amount / goal.target_amount) * 100)
+    : 0;
+
+  // 횟수 진행률 계산
+  const countProgress = goal.target_count && goal.target_count > 0
+    ? Math.min(100, (goal.current_count / goal.target_count) * 100)
+    : 0;
+
+  // 완료 상태 체크
+  const isAmountComplete = goal.target_amount
+    ? goal.current_amount >= goal.target_amount
+    : true;
+  const isCountComplete = goal.target_count
+    ? goal.current_count >= goal.target_count
+    : true;
+
+  // 전체 진행률 계산 (OR 조건 - 하나만 완료해도 성공)
+  let overallProgress = 0;
+  let isComplete = false;
+
+  if (goal.challenge_mode === 'amount') {
+    overallProgress = amountProgress;
+    isComplete = isAmountComplete;
+  } else if (goal.challenge_mode === 'count') {
+    overallProgress = countProgress;
+    isComplete = isCountComplete;
+  } else { // 'both' - OR 조건
+    overallProgress = Math.max(amountProgress, countProgress);
+    isComplete = isAmountComplete || isCountComplete;
+  }
+
+  // 진행 상태 텍스트
+  let progressText = '';
+  if (isComplete) {
+    progressText = '목표 달성! 🎉';
+  } else if (daysLeft === 0 && targetDate) {
+    progressText = '기한 만료';
+  } else if (daysLeft > 0) {
+    progressText = `${daysLeft}일 남음`;
+  } else {
+    progressText = '진행 중';
+  }
+
+  return {
+    amountProgress,
+    countProgress,
+    overallProgress,
+    isAmountComplete,
+    isCountComplete,
+    isComplete,
+    daysLeft,
+    progressText,
+  };
+};

--- a/src/types/goals/database.ts
+++ b/src/types/goals/database.ts
@@ -1,0 +1,34 @@
+import { Category } from '../budget';
+
+export interface Goal {
+  id: string;
+  user_id: string;
+  category_id: string | null;
+  title: string;
+  description: string | null;
+  type: 'save_money' | 'reduce_expense' | 'increase_income' | 'custom';
+  target_amount: number | null;
+  current_amount: number;
+  target_count: number | null;
+  current_count: number;
+  target_date: string | null;
+  status: 'active' | 'completed' | 'paused' | 'cancelled';
+  created_from_date: string;
+  reason: string | null;
+  challenge_mode: 'amount' | 'count' | 'both';
+  created_at: string;
+  updated_at: string;
+  category?: Category;
+}
+
+export interface GoalFormData {
+  title: string;
+  description?: string | null;
+  reason?: string | null;
+  type: 'save_money' | 'reduce_expense' | 'increase_income' | 'custom';
+  target_amount?: number | null;
+  target_count?: number | null;
+  target_date?: string | null;
+  challenge_mode: 'amount' | 'count' | 'both';
+  category_id?: string | null;
+}

--- a/src/types/goals/index.ts
+++ b/src/types/goals/index.ts
@@ -1,0 +1,5 @@
+export type {
+  Goal,
+  GoalFormData,
+} from './database';
+export type { GoalProgressInfo } from './ui';

--- a/src/types/goals/ui.ts
+++ b/src/types/goals/ui.ts
@@ -1,0 +1,10 @@
+export interface GoalProgressInfo {
+  amountProgress: number;
+  countProgress: number;
+  overallProgress: number;
+  isAmountComplete: boolean;
+  isCountComplete: boolean;
+  isComplete: boolean;
+  daysLeft: number;
+  progressText: string;
+}


### PR DESCRIPTION
기능 구현
1. 목표 도메인 구성
2. 가계부 챌린지와 연동
3. 가계부 챌린지를 생성 후, 가계부 내에 항목이 추가 및 삭제될 경우 챌린지 수정 모달이 나타나도록 구현
4. 알림 기능 구현
5. 목표 설정 진행률 표시
6. 하나의 지출/수입 카테고리에서 여러 챌린지를 생성했을 경우, 3번의 동작하면서 모든 챌린지를 수정해야 하도록 기능 구현
7. 챌린지 현황 기능

TODO
1. 회고(감사, 성찰) 도메인과 연동
2. 질문 도메인과 연동
3. 이웃관계에 따른 공개여부 설정(가계부 챌린지는 비공개)
4. 목표에 대한 좋아요 기능 설정